### PR TITLE
Update puget dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,8 +7,8 @@
                  [org.clojure/tools.nrepl "0.2.7"]
 
                  [io.aviso/pretty "0.1.14"]
-                 [mvxcvi/whidbey "0.5.0"]
-                 [mvxcvi/puget "0.7.1"]
+                 [mvxcvi/whidbey "1.0.0"]
+                 [mvxcvi/puget "0.8.1"]
                  [robert/hooke "1.3.0"]
                  [org.clojars.brenton/google-diff-match-patch "0.1"]]
   :test-selectors {:default (complement :demo)

--- a/src/ultra/colorscheme.clj
+++ b/src/ultra/colorscheme.clj
@@ -60,7 +60,7 @@
                      color-scheme
                      (load-colorscheme color-scheme))]
     (alter-var-root
-      #'whidbey.render/puget-options
+      #'whidbey.render/options
       merge
       (assoc opts :color-scheme color-scheme))
     (set-pretty-colors color-scheme)))

--- a/src/ultra/printer.clj
+++ b/src/ultra/printer.clj
@@ -6,4 +6,4 @@
   "Puget's cprint, set to always use the Puget options."
   {:added "0.1.3"}
   [x]
-  (printer/cprint x render/puget-options))
+  (printer/cprint x render/options))


### PR DESCRIPTION
This version of puget has explicit support for Clojure 1.7 and should not display warnings because of shadowed identifiers from Clojure proper.