### PR TITLE
prn-diff: dispatch by types of diffs, not actual/expected

### DIFF
--- a/src/ultra/test/diff.clj
+++ b/src/ultra/test/diff.clj
@@ -54,10 +54,10 @@
   {:added "0.1.3"}
   (fn [a b actual expected]
     (cond
-      (and (string? actual) (string? expected)) ::diff-strs
-      (and (vector? actual) (vector? expected)) ::diff-vecs
-      (and (list? actual) (list? expected)) ::diff-vecs
-      (not= (class actual) (class expected)) ::wrong-class
+      (and (string? a) (string? b)) ::diff-strs
+      (and (vector? a) (vector? b)) ::diff-vecs
+      (and (list? a) (list? b)) ::diff-vecs
+      (not= (class a) (class b)) ::wrong-class
       :default [a b actual expected])))
 
 (defmethod prn-diffs ::diff-strs


### PR DESCRIPTION
Note: this fixes issue #37

This means that diffs will be printed whenever possible.

For example, a comparison like:
```
(is (= (hash-map 1 1) (array-map 1 2)))
```
will now result in:
```
...
expected: {1 1}
  actual: {1 2}

    diff: - {1 1}
          + {1 2}
```
rather than:
```
expected: {1 2} to be an instance of clojure.lang.PersistentArrayMap
     was: {1 2} is an instance of clojure.lang.PersistentArrayMap
```