### PR TITLE
Better test reporting for logical expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ pom.xml.asc
 /TODO
 /.lein-*
 /.nrepl-port
+/.idea
+*.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.4.2
+ * Better test reporting on logical expressions
+
 ## 0.4.1
  * Fixed a bug wherein the default colorscheme was devoid of colors
  * Added logic to fall back to Ultra version 0.3.4 in the event that Ultra was being used in a project with Clojure version <1.7.0

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject venantius/ultra "0.4.1"
+(defproject venantius/ultra "0.4.2-SNAPSHOT"
   :description "Ultra: A Leiningen plugin for a superior development environment"
   :url "http://github.com/venantius/ultra"
   :license {:name "Eclipse Public License"

--- a/src/ultra/test.clj
+++ b/src/ultra/test.clj
@@ -40,13 +40,14 @@
         (doseq [[actual [a b]] diffs
                 :when (or a b)]
           (diff/prn-diffs a b actual expected))
-        (diff/print-expected actual expected))))
+        (diff/print-expected actual expected))
+      (logic/maybe-print-values event)))
 
   (defmethod assert-expr :default [msg form]
     (cond
       (and (sequential? form) (logic/logic-ops (first form)))
       (logic/assert-logic msg form)
       (and (sequential? form) (function? (first form)))
-      (assert-predicate msg form)
+      (logic/assert-predicate msg form)
       :else
       (assert-any msg form))))

--- a/src/ultra/test.clj
+++ b/src/ultra/test.clj
@@ -3,8 +3,8 @@
   (:require [clojure.data :as data]
             [clojure.pprint :as pp]
             [puget.color.ansi :as ansi]
-            [ultra.test.diff :as diff]))
-
+            [ultra.test.diff :as diff]
+            [ultra.test.logic :as logic]))
 
 (defn generate-diffs
   [a more]
@@ -40,4 +40,13 @@
         (doseq [[actual [a b]] diffs
                 :when (or a b)]
           (diff/prn-diffs a b actual expected))
-        (diff/print-expected actual expected)))))
+        (diff/print-expected actual expected))))
+
+  (defmethod assert-expr :default [msg form]
+    (cond
+      (and (sequential? form) (logic/logic-ops (first form)))
+      (logic/assert-logic msg form)
+      (and (sequential? form) (function? (first form)))
+      (assert-predicate msg form)
+      :else
+      (assert-any msg form))))

--- a/src/ultra/test/diff.clj
+++ b/src/ultra/test/diff.clj
@@ -15,12 +15,15 @@
              (s/replace
                x #"\n" (str "\n" whitespace))))))
 
+(defn pretty [s]
+  (s/trim (indent (with-out-str (cprint s)) 10)))
+
 (defn print-expected
   "Pretty-prints expected and actual values."
   {:added "0.1.3"}
   [actual expected]
-  (let [expected (s/trim (indent (with-out-str (cprint expected)) 10))
-        actual (s/trim (indent (with-out-str (cprint actual)) 10))]
+  (let [expected (pretty expected)
+        actual (pretty actual)]
     (println "\nexpected:" expected)
     (println "  actual:" actual)))
 

--- a/src/ultra/test/diff.clj
+++ b/src/ultra/test/diff.clj
@@ -15,7 +15,9 @@
              (s/replace
                x #"\n" (str "\n" whitespace))))))
 
-(defn pretty [s]
+(defn pretty
+  {:added "0.4.2"}
+  [s]
   (s/trim (indent (with-out-str (cprint s)) 10)))
 
 (defn print-expected

--- a/src/ultra/test/logic.clj
+++ b/src/ultra/test/logic.clj
@@ -1,0 +1,21 @@
+(ns ultra.test.logic
+  (:require [clojure.test :as test]))
+
+(def logic-ops
+  #{'not 'and 'or})
+
+(defn quote-logic [form]
+  (if (and (sequential? form) (logic-ops (first form)))
+    `(list '~(first form) ~@(map quote-logic (rest form)))
+    form))
+
+(defn assert-logic [msg form]
+  `(let [result# ~form]
+     (test/do-report
+       {:type (if result# :pass :fail)
+        :message ~msg
+        :expected '~form
+        :actual ~(if (and (sequential? form) (= 'not (first form)))
+                   (quote-logic (second form))
+                   `(list '~'not ~(quote-logic form)))})
+     result#))

--- a/src/ultra/test/logic.clj
+++ b/src/ultra/test/logic.clj
@@ -7,12 +7,18 @@
 (def logic-ops
   #{'not 'and 'or})
 
-(defn quote-logic [form]
+(defn quote-logic
+  "Preserves logic expressions to assist debugging."
+  {:added "0.4.2"}
+  [form]
   (if (and (seq? form) (logic-ops (first form)))
     `(list '~(first form) ~@(map quote-logic (rest form)))
     form))
 
-(defn assert-logic [msg form]
+(defn assert-logic
+  "Preserves useful information in the :with-values key of the test."
+  {:added "0.4.2"}
+  [msg form]
   `(let [result# ~form]
      (test/do-report
        {:type (if result# :pass :fail)
@@ -22,7 +28,10 @@
         :with-values ~(quote-logic form)})
      result#))
 
-(defn assert-predicate [msg form]
+(defn assert-predicate
+  "Replaces core.test/assert-predicate to report more useful output."
+  {:added "0.4.2"}
+  [msg form]
   (let [args (rest form)
         pred (first form)]
     `(let [values# (list ~@args)
@@ -37,7 +46,10 @@
                          hint#)})
        result#)))
 
-(defn maybe-print-values [{:keys [with-values]}]
+(defn maybe-print-values
+  "Reports the expression values of a test result when they exist."
+  {:added "0.4.2"}
+  [{:keys [with-values]}]
   (when with-values
     (println
       "\n  values:"

--- a/src/ultra/test/logic.clj
+++ b/src/ultra/test/logic.clj
@@ -1,11 +1,14 @@
 (ns ultra.test.logic
-  (:require [clojure.test :as test]))
+  (:require [clojure.test :as test]
+            [clojure.string :as s]
+            [ultra.printer :refer [cprint]]
+            [ultra.test.diff :refer [pretty]]))
 
 (def logic-ops
   #{'not 'and 'or})
 
 (defn quote-logic [form]
-  (if (and (sequential? form) (logic-ops (first form)))
+  (if (and (seq? form) (logic-ops (first form)))
     `(list '~(first form) ~@(map quote-logic (rest form)))
     form))
 
@@ -15,7 +18,27 @@
        {:type (if result# :pass :fail)
         :message ~msg
         :expected '~form
-        :actual ~(if (and (sequential? form) (= 'not (first form)))
-                   (quote-logic (second form))
-                   `(list '~'not ~(quote-logic form)))})
+        :actual result#
+        :with-values ~(quote-logic form)})
      result#))
+
+(defn assert-predicate [msg form]
+  (let [args (rest form)
+        pred (first form)]
+    `(let [values# (list ~@args)
+           result# (apply ~pred values#)
+           hint# (cons '~pred values#)]
+       (test/do-report
+         {:type (if result# :pass :fail)
+          :message ~msg
+          :expected '~form
+          :actual result#
+          :with-values (when (not= '~form hint#)
+                         hint#)})
+       result#)))
+
+(defn maybe-print-values [{:keys [with-values]}]
+  (when with-values
+    (println
+      "\n  values:"
+      (pretty with-values))))

--- a/test/ultra/test/logic_test.clj
+++ b/test/ultra/test/logic_test.clj
@@ -1,0 +1,16 @@
+(ns ultra.test.logic-test
+  (:require
+    [clojure.test :refer :all]
+    [ultra.test.logic :as logic]))
+
+(deftest quote-logic-test
+  (is (= 'false
+         (logic/quote-logic 'false)))
+  (is (= `(list ~''and (~'= 1 1) (list ~''and (list ~''or nil 1)))
+         (logic/quote-logic '(and (= 1 1) (and (or nil 1)))))))
+
+(deftest assert-logic-test
+  (is (logic/assert-logic "literal true" true))
+  (is (logic/assert-logic "and" (and true)))
+  (is (logic/assert-logic "not" (not false)))
+  (is (logic/assert-logic "complex logic" (or (and true (= 1 1)) false))))

--- a/test/ultra/test_test.clj
+++ b/test/ultra/test_test.clj
@@ -20,3 +20,7 @@
     (is (and (:name pirate)
              (or (empty? pirate) (:age pirate))))
     (is (not (= (:rating pirate) :notorious)))))
+
+(deftest predicate-values-are-shown-when-appropriate
+  (is (odd? 2))
+  (is (odd? (+ 1 (inc 0)))))

--- a/test/ultra/test_test.clj
+++ b/test/ultra/test_test.clj
@@ -12,3 +12,11 @@
                      :well-how-about-some-more?
                      :howd-you-like-them-apples!]]
     (is (every? (set (keys {:a 1 :b 5})) long-vector))))
+
+(deftest logical-expressions-are-preserved
+  (let [pirate {:name "Edward Teach"
+                :nickname "Blackbeard"
+                :rating :notorious}]
+    (is (and (:name pirate)
+             (or (empty? pirate) (:age pirate))))
+    (is (not (= (:rating pirate) :notorious)))))


### PR DESCRIPTION
Instead of opaque failures:
expected: (and (:name pirate) (or (empty? pirate) (:age pirate)))
  actual: nil

See what part of the logical expression does not meet your expectation:
expected: (and (:name pirate) (or (empty? pirate) (:age pirate)))
  actual: (not (and "Edward Teach" (or false nil)))

![image](https://cloud.githubusercontent.com/assets/49298/15096267/2c736bde-14a6-11e6-9ec2-7b95037f3bbb.png)
