### PR TITLE
Do not fail if an invalid semver found for Clojure artifact

### DIFF
--- a/src/ultra/plugin/utils.clj
+++ b/src/ultra/plugin/utils.clj
@@ -28,9 +28,10 @@
   version is specified, returns true."
   {:added "0.4.1"}
   [project]
-  (if-let [clj (some clojure-dep? (:dependencies project))]
-    (not (semver/older? (second clj) "1.7.0"))
-    true))
+  (let [[_ clj] (some clojure-dep? (:dependencies project))]
+    (or (not clj)
+        (not (semver/valid-format? clj))
+        (not (semver/older? clj "1.7.0")))))
 
 (defn- find-plugin-version
   "Looks up the plugins in the project map and tries to find the version


### PR DESCRIPTION
The check fails in case there's an invalid version identifier which can happen if the project uses something like `lein-modules` where a placeholder like `_` is used for a version.