### PR TITLE
Check number of arguments to = at read time

### DIFF
--- a/src/ultra/test.clj
+++ b/src/ultra/test.clj
@@ -18,9 +18,10 @@
   {:added "0.3.3"}
   []
   (defmethod assert-expr '= [msg [_ a & more]]
-  `(let [a# ~a]
-     (if-let [more# (seq (list ~@more))]
-       (let [result# (apply = a# more#)]
+    (if (seq more)
+      `(let [a# ~a
+             more# (seq (list ~@more))
+             result# (apply = a# more#)]
          (if result#
            (do-report {:type :pass, :message ~msg,
                        :expected a#, :actual more#})
@@ -28,7 +29,7 @@
                        :expected a#, :actual more#,
                        :diffs (generate-diffs a# more#)}))
          result#)
-       (throw (Exception. "= expects more than one argument")))))
+      `(throw (Exception. "= expects more than one argument"))))
 
   (defmethod report :fail
     [{:keys [type expected actual diffs message] :as event}]


### PR DESCRIPTION
This is the same as pjstadig/humane-test-output#21. When ultra has been activated, the overwritten `=` method on `assert-expr` triggers nuisance warnings from the [eastwood](https://github.com/jonase/eastwood) static analysis tool. The warning message is "Test expression is always logicla true or always logical false." This PR fixes the nuisance warnings by checking the number of arguments at read time, rather than at run time.