### PR TITLE
Flush diff output

### DIFF
--- a/src/ultra/test/diff.clj
+++ b/src/ultra/test/diff.clj
@@ -71,7 +71,7 @@
   [a b actual expected]
   (print-expected actual expected)
   (print "\n    diff:")
-  (println (str-diff/clean-difform-str a b)))
+  (print (str-diff/clean-difform-str a b)))
 
 (defmethod prn-diffs ::wrong-class
   [a b actual expected]
@@ -86,7 +86,7 @@
                                    (class b)))]
       (println (clojure.string/trim (indent a 10)))
       (print "     was: ")
-      (println (indent b 10)))))
+      (print (indent b 10)))))
 
 (defmethod prn-diffs ::diff-vecs
   [a b actual expected]
@@ -114,5 +114,5 @@
   (when b
     (print (ansi/sgr " + " :green))
     (let [b (with-out-str (cprint b))]
-      (print (indent b 12))))
-  (println))
+      (print (s/trimr (indent b 12)))
+      (println))))

--- a/src/ultra/test/diff.clj
+++ b/src/ultra/test/diff.clj
@@ -71,8 +71,7 @@
   [a b actual expected]
   (print-expected actual expected)
   (print "\n    diff:")
-  (print (str-diff/clean-difform-str a b))
-  (flush))
+  (println (str-diff/clean-difform-str a b)))
 
 (defmethod prn-diffs ::wrong-class
   [a b actual expected]
@@ -87,8 +86,7 @@
                                    (class b)))]
       (println (clojure.string/trim (indent a 10)))
       (print "     was: ")
-      (print (indent b 10))
-      (flush))))
+      (println (indent b 10)))))
 
 (defmethod prn-diffs ::diff-vecs
   [a b actual expected]
@@ -117,4 +115,4 @@
     (print (ansi/sgr " + " :green))
     (let [b (with-out-str (cprint b))]
       (print (indent b 12))))
-  (flush))
+  (println))

--- a/src/ultra/test/diff.clj
+++ b/src/ultra/test/diff.clj
@@ -71,7 +71,8 @@
   [a b actual expected]
   (print-expected actual expected)
   (print "\n    diff:")
-  (print (str-diff/clean-difform-str a b)))
+  (print (str-diff/clean-difform-str a b))
+  (flush))
 
 (defmethod prn-diffs ::wrong-class
   [a b actual expected]
@@ -86,7 +87,8 @@
                                    (class b)))]
       (println (clojure.string/trim (indent a 10)))
       (print "     was: ")
-      (print (indent b 10)))))
+      (print (indent b 10))
+      (flush))))
 
 (defmethod prn-diffs ::diff-vecs
   [a b actual expected]
@@ -114,4 +116,5 @@
   (when b
     (print (ansi/sgr " + " :green))
     (let [b (with-out-str (cprint b))]
-      (print (indent b 12)))))
+      (print (indent b 12))))
+  (flush))


### PR DESCRIPTION
When tests take a while to run, the diff output is not displayed immediately on failing tests, because it doesn't end in a newline.
I've added a flush in these cases so that the output is visible as soon as the test fails (or maybe it would be better to add a newline at the end?)