### PR TITLE
[circleci] Migrating to Circle 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,8 @@
 version: 2
 jobs:
   build:
-    working_directory: ~/cci-demo-clojure
     docker:
-      - image: circleci/clojure:lein-2.7.1
+      - image: circleci/clojure:lein-2.8.1
     environment:
       LEIN_ROOT: nbd
       JVM_OPTS: -Xmx3200m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/cci-demo-clojure
+    docker:
+      - image: circleci/clojure:lein-2.7.1
+    environment:
+      LEIN_ROOT: nbd
+      JVM_OPTS: -Xmx3200m
+    steps:
+      - checkout
+      - restore_cache:
+          key: ultra-{{ checksum "project.clj" }}
+      - run: lein deps
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: ultra-{{ checksum "project.clj" }}
+      - run: lein test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: clojure
-notifications:
-  email: false
-script: 
-  - lein test

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-test:
-  override:
-    - lein test


### PR DESCRIPTION
Circle's original CI infrastructure has a sunset date of August of this year, so we might as well move everything over now. 