### PR TITLE
[ultra] Require nrepl or clojure.tools.nrepl dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## 0.6.0
+ * Migrates to `nrepl` from `clojure.tools.nrepl`
+
 ## 0.5.3
-* Removes logical expression hints, they could cause double evaluation in test.
+ * Removes logical expression hints, they could cause double evaluation in test.
 
 ## 0.5.2
  * Changed the printing behavior of test results to flush test output at the end of the test, making output clearer in cases where multi-threaded tests print to *out*
@@ -39,7 +42,7 @@
  * Remove an embarrassing println statement
 
 ## 0.3.1
- * Fix test initialization to be an injection that triggers a hook. 
+ * Fix test initialization to be an injection that triggers a hook.
 
 ## 0.3.0
  * Avoids initialization of unused features.
@@ -52,7 +55,7 @@
  * Modifies the loading of the nREPL middleware to play nicely with CIDER.
 
 ## 0.2.0
- * Moves Java function injection to be a hook sitting on clojure.tools.nrepl.server/start-server, which is a total hack but it seems to actually work, unlike literally everything else I've tried. 
+ * Moves Java function injection to be a hook sitting on clojure.tools.nrepl.server/start-server, which is a total hack but it seems to actually work, unlike literally everything else I've tried.
  * Removes Vinyasa dependency.
  * Moving test activation from a defonce, which seemed to screw up Kibit.
  * General cleanup and refactoring.

--- a/project.clj
+++ b/project.clj
@@ -1,17 +1,16 @@
-(defproject venantius/ultra "0.5.3"
+(defproject venantius/ultra "0.6.0-SNAPSHOT"
   :description "Ultra: A Leiningen plugin for a superior development environment"
   :url "http://github.com/venantius/ultra"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/tools.nrepl "0.2.12"]
-
+  :dependencies [[nrepl "0.4.0"]
                  [grimradical/clj-semver "0.3.0" :exclusions [org.clojure/clojure]]
-                 [io.aviso/pretty "0.1.30"]
-                 [mvxcvi/whidbey "1.3.0"]
-                 [mvxcvi/puget "1.0.1"]
+                 [io.aviso/pretty "0.1.35"]
+                 [mvxcvi/whidbey "1.3.2"]
+                 [mvxcvi/puget "1.0.3"]
                  [org.clojars.brenton/google-diff-match-patch "0.1"]
                  [robert/hooke "1.3.0"]
-                 [venantius/glow "0.1.4" :exclusions [hiccup garden]]]
+                 [venantius/glow "0.1.5" :exclusions [hiccup garden]]]
   :profiles {:dev {:dependencies [[circleci/bond "0.2.9"]
                                   [org.clojure/clojure "1.8.0"]]}}
   :test-selectors {:default (complement :demo)

--- a/src/ultra/hardcore.clj
+++ b/src/ultra/hardcore.clj
@@ -1,8 +1,14 @@
 (ns ultra.hardcore
   "See what I did there?"
-  (:require [clojure.tools.nrepl.server]
-            [ultra.colorscheme :as colorscheme]
+  (:require [ultra.colorscheme :as colorscheme]
             [robert.hooke :refer [add-hook]]))
+
+;; For reasons that aren't totally clear to me, we need this import to find clojure.test?
+(if (find-ns 'clojure.tools.nrepl)
+  (require
+   '[clojure.tools.nrepl.server :as nrepl-server])
+  (require
+   '[nrepl.server :as nrepl-server]))
 
 (def configured? (atom {}))
 

--- a/src/ultra/repl.clj
+++ b/src/ultra/repl.clj
@@ -1,13 +1,21 @@
 (ns ultra.repl
   (:require [clojure.main :as main]
             [clojure.repl :as repl]
-            [clojure.tools.nrepl.server]
             [glow.terminal]
             [glow.colorschemes]
             [glow.parse]
             [io.aviso.repl :as pretty-repl]
             [puget.color.ansi :as ansi]
             [ultra.printer :refer [cprint]]))
+
+;; Compatibility with the legacy tools.nrepl and the new nREPL 0.4.x.
+;; The assumption is that if someone is using old lein repl or boot repl
+;; they'll end up using the tools.nrepl, otherwise the modern one.
+(if (find-ns 'clojure.tools.nrepl)
+  (require
+   '[clojure.tools.nrepl.server :as nrepl-server])
+  (require
+   '[nrepl.server :as nrepl-server]))
 
 (defmacro source
   "Prints the source code for the given symbol, if it can find it.
@@ -84,10 +92,18 @@
   "Alter the default handler to include the provided middleware."
   {:added "0.1.0"}
   [middleware]
-  (alter-var-root
-   #'clojure.tools.nrepl.server/default-handler
-   partial
-   middleware))
+  ;; Compatibility with the legacy tools.nrepl and the new nREPL 0.4.x.
+  ;; The assumption is that if someone is using old lein repl or boot repl
+  ;; they'll end up using the tools.nrepl, otherwise the modern one.
+  (if (find-ns 'clojure.tools.nrepl)
+    (alter-var-root
+     #'clojure.tools.nrepl.server/default-handler
+     partial
+     middleware)
+    (alter-var-root
+     #'nrepl.server/default-handler
+     partial
+     middleware)))
 
 (defn add-pretty-middleware
   "Add Aviso's Pretty functionality"

--- a/src/ultra/repl/whidbey.clj
+++ b/src/ultra/repl/whidbey.clj
@@ -2,6 +2,7 @@
   "Unfortunately, Whidbey has some import side-effects that require us to
   dynamically import this namespace."
   (:require [clojure.tools.nrepl.middleware.render-values :refer [render-values]]
+            ;; note that the above dependency comes from Whidbey, not nREPL.
             [ultra.repl :refer [add-middleware]]))
 
 (defn add-whidbey-middleware


### PR DESCRIPTION
clojure.tools.nrepl is now officially deprecated and has been replaced
with nrepl/nrepl. This commit updates all direct references to
clojure.tools.nrepl to use a dynamic import that checks to see if
clojure.tools.nrepl is on the path and otherwise to use the new nrepl.

As we rely on a significant amount of functionality in Whidbey/Puget,
those will also need to have their references updated.

This PR resolves #95