### PR TITLE
[ultra] Require nrepl or clojure.tools.nrepl dynamically (fix conflict)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [grimradical/clj-semver "0.3.0" :exclusions [org.clojure/clojure]]
                  [io.aviso/pretty "0.1.35"]
                  [mvxcvi/whidbey "1.3.2"]
-                 [mvxcvi/puget "1.0.3"]
+                 [mvxcvi/puget "1.1.0"]
                  [org.clojars.brenton/google-diff-match-patch "0.1"]
                  [robert/hooke "1.3.0"]
                  [venantius/glow "0.1.5" :exclusions [hiccup garden]]]


### PR DESCRIPTION
clojure.tools.nrepl is now officially deprecated and has been replaced
with nrepl/nrepl. This commit updates all direct references to
clojure.tools.nrepl to use a dynamic import that checks to see if
clojure.tools.nrepl is on the path and otherwise to use the new nrepl.

As we rely on a significant amount of functionality in Whidbey/Puget,
those will also need to have their references updated.

This commit fixes a merge conflict on project.clj.